### PR TITLE
Add custom action for automating dependabot automerge / auto approval

### DIFF
--- a/actions/dependabot-automerge/README.md
+++ b/actions/dependabot-automerge/README.md
@@ -22,7 +22,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  test:
+  dependabot-automerge:
     runs-on: ubuntu-latest
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
@@ -30,9 +30,11 @@ jobs:
         uses: mozilla/syseng-pod/actions/dependabot-automerge
 ```
 
-The following repo settings should also be enabled:
+the `contents` and `pull-requests` [token](https://docs.github.com/en/actions/security-guides/automatic-token-authentication) permissions (used by the action) need to be set to `write` so that the automation can leave comments, approve the PR, and enable auto-merge.
 
-- Allow Github Actions to create and approve pull requests should be checked ([docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#preventing-github-actions-from-creating-or-approving-pull-requests))
+## Repo Configuration:
+
+- `Allow Github Actions to create and approve pull requests` should be checked ([docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#preventing-github-actions-from-creating-or-approving-pull-requests))
 - the chosen merge strategy should be enabled on the repo ([docs](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges))
 - [Requiring reviews](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#require-pull-request-reviews-before-merging) from Codeowners should be disabled for files that Dependabot would update (e.g. `poetry.lock`), since bots can't be listed as Codeowners
 - It's best to use required status checks with this action (e.g. for linting and tests) and require that those status checks are successful before merging is allowed ([docs](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#require-status-checks-before-merging))

--- a/actions/dependabot-automerge/README.md
+++ b/actions/dependabot-automerge/README.md
@@ -1,0 +1,45 @@
+# Dependabot Autoapproval and Automerge
+
+This GitHub custom action enables automatic approval and merging of Dependabot pull requests (PRs) based on specified conditions.
+
+## Inputs
+
+- `merge-strategy`: The merge strategy to use when enabling automerge. Defaults to `squash`.
+- `prod-semver-autoapprovals`: Semver levels for which to automatically approve the PR for production dependencies. Defaults to `patch`.
+- `dev-semver-autoapprovals`: Semver levels for which to automatically approve the PR for development dependencies. Defaults to `major,minor,patch`.
+
+## Usage
+
+To use this action, include the following YAML configuration in a workflow file (e.g., `.github/workflows/dependabot_auto_merge.yml`):
+
+```yaml
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Enable Dependabot automation
+        uses: mozilla/syseng-pod/actions/dependabot-automerge
+```
+
+The following repo settings should also be enabled:
+
+- Allow Github Actions to create and approve pull requests should be checked ([docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#preventing-github-actions-from-creating-or-approving-pull-requests))
+- [Requiring reviews](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#require-pull-request-reviews-before-merging) from Codeowners should be disabled for files that Dependabot would update, since bots can't be listed as Codeowners
+- It's best to use required status checks with this action (e.g. for linting and tests) and require that those status checks are successful before merging is allowed ([docs](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#require-status-checks-before-merging))
+
+## How It Works
+
+- It fetches the metadata of the Dependabot PR
+- The action executes the `review_pr.py` script, which reviews the PR and action inputs to determine if it should be automatically approved or not
+- The action enables auto-merge on the PR
+- If the PR should be approved, the action approves the PR
+- If the PR should not be approved, the action adds a comment on the PR explaining why it wasn't approved

--- a/actions/dependabot-automerge/README.md
+++ b/actions/dependabot-automerge/README.md
@@ -4,9 +4,9 @@ This GitHub custom action enables automatic approval and merging of Dependabot p
 
 ## Inputs
 
-- `merge-strategy`: The merge strategy to use when enabling automerge. Defaults to `squash`.
-- `prod-semver-autoapprovals`: Semver levels for which to automatically approve the PR for production dependencies. Defaults to `patch`.
-- `dev-semver-autoapprovals`: Semver levels for which to automatically approve the PR for development dependencies. Defaults to `major,minor,patch`.
+- `merge-strategy`: The merge strategy to use when enabling automerge. Possible values are `merge`, `rebase`, and `squash`. Defaults to `squash`.
+- `prod-semver-autoapprovals`: Comma-delimited list of semver levels for which to automatically approve the PR for production dependencies. Defaults to `patch`.
+- `dev-semver-autoapprovals`: Comma-delimited list of semver levels for which to automatically approve the PR for development dependencies. Defaults to `major,minor,patch`.
 
 ## Usage
 
@@ -33,7 +33,8 @@ jobs:
 The following repo settings should also be enabled:
 
 - Allow Github Actions to create and approve pull requests should be checked ([docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#preventing-github-actions-from-creating-or-approving-pull-requests))
-- [Requiring reviews](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#require-pull-request-reviews-before-merging) from Codeowners should be disabled for files that Dependabot would update, since bots can't be listed as Codeowners
+- the chosen merge strategy should be enabled on the repo ([docs](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges))
+- [Requiring reviews](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#require-pull-request-reviews-before-merging) from Codeowners should be disabled for files that Dependabot would update (e.g. `poetry.lock`), since bots can't be listed as Codeowners
 - It's best to use required status checks with this action (e.g. for linting and tests) and require that those status checks are successful before merging is allowed ([docs](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#require-status-checks-before-merging))
 
 ## How It Works

--- a/actions/dependabot-automerge/action.yml
+++ b/actions/dependabot-automerge/action.yml
@@ -1,0 +1,53 @@
+name: 'Dependabot Automerge'
+description: 'Automatically approve and merge Dependabot PRs'
+inputs:
+  merge-strategy:
+    description: Merge strategy to use when enabling automerge
+    required: true
+    default: 'squash'
+  prod-semver-autoapprovals:
+    description: 'Semver levels for which to automatically approve the PR for production dependencies'
+    required: true
+    default: 'patch'
+  dev-semver-autoapprovals:
+    description: 'Semver levels for which to automatically approve the PR for development dependencies'
+    required: true
+    default: 'major,minor,patch'
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+    - shell: bash
+      run: pip install click
+    - name: Dependabot metadata
+      id: dependabot-metadata
+      uses: dependabot/fetch-metadata@v1
+      with:
+        github-token: ${{ github.token }}
+    - name: Review PR
+      id: review-pr
+      shell: python
+      run: review_pr.py \
+          --semver-level "${{ steps.dependabot-metadata.outputs.update-type }}" \
+          --dependency-type "${{ steps.dependabot-metadata.outputs.dependency-type }}" \
+          --prod-semver-autoapprovals ${{ inputs.prod-semver-autoapprovals }} \
+          --dev-semver-autoapprovals ${{ inputs.dev-semver-autoapprovals }}
+    - name: Enable auto-merge on PR
+      shell: bash
+      run: gh pr merge --auto --${{ inputs.merge-strategy }} "${{ github.event.pull_request.html_url }}"
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+    - name: Approve PR
+      if: ${{ steps.review-pr.outputs.should-approve == 'true' }}
+      shell: bash
+      run: gh pr review "${{ github.event.pull_request.html_url }}" --approve --body "${{ steps.review-pr.outputs.review-message }}"
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+    - name: Comment on non-approval of PR
+      if: ${{ steps.review-pr.outputs.should-approve == 'false' }}
+      shell: bash
+      run: gh pr comment "${{ github.event.pull_request.html_url }}" --body "${{ steps.review-pr.outputs.review-message }}"
+      env:
+        GITHUB_TOKEN: ${{ github.token }}

--- a/actions/dependabot-automerge/review_pr.py
+++ b/actions/dependabot-automerge/review_pr.py
@@ -1,0 +1,109 @@
+import os
+from enum import StrEnum, auto
+
+import click
+
+UPDATE_TYPE_PREFIX = "version-update:semver-"
+DEPENDENCY_TYPE_PREFIX = "direct:"
+
+
+class DependencyType(StrEnum):
+    DEVELOPMENT = auto()
+    PRODUCTION = auto()
+
+
+class SemverLevel(StrEnum):
+    MAJOR = auto()
+    MINOR = auto()
+    PATCH = auto()
+
+
+def set_output(outputs):
+    with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+        for name, value in outputs.items():
+            f.write(f"{name}={value}\n")
+
+
+def parse_semver_level(ctx, option, value: str):
+    return SemverLevel(value.removeprefix(UPDATE_TYPE_PREFIX))
+
+
+def parse_dependency_type(ctx, option, value: str):
+    return DependencyType(value.removeprefix(DEPENDENCY_TYPE_PREFIX))
+
+
+def parse_semver_autoapprovals(ctx, option, value):
+    try:
+        return [SemverLevel(v.strip()) for v in value.split(",")]
+    except ValueError:
+        raise click.BadParameter(
+            f"format must be a comma-separated list of semver values, e.g. {','.join([e.value for e in SemverLevel])}"
+        )
+
+
+approval_message_template = "The {semver_level} update of this {dependency_type} dependency was automatically approved."
+denial_message_template = "The {semver_level} update of this {dependency_type} dependency was not automatically approved. For {dependency_type} dependencies, these semver updates can be automatically approved: {auto_approvals}"
+
+
+def review_pr(
+    *,
+    dependency_type: DependencyType,
+    semver_level: SemverLevel,
+    prod_semver_autoapprovals: list[SemverLevel],
+    dev_semver_autoapprovals: list[SemverLevel],
+) -> tuple[bool, str]:
+    auto_approvals = (
+        prod_semver_autoapprovals
+        if dependency_type == DependencyType.PRODUCTION
+        else dev_semver_autoapprovals
+    )
+    is_semver_allowed = semver_level in auto_approvals
+    message = (
+        approval_message_template.format(
+            semver_level=semver_level, dependency_type=dependency_type
+        )
+        if is_semver_allowed
+        else denial_message_template.format(
+            semver_level=semver_level,
+            dependency_type=dependency_type,
+            auto_approvals=",".join(auto_approvals),
+        )
+    )
+    return is_semver_allowed, message
+
+
+@click.command()
+@click.option(
+    "--semver-level",
+    type=click.Choice([UPDATE_TYPE_PREFIX + e.value for e in SemverLevel]),
+    callback=parse_semver_level,
+)
+@click.option(
+    "--dependency-type",
+    type=click.Choice([DEPENDENCY_TYPE_PREFIX + e.value for e in DependencyType]),
+    callback=parse_dependency_type,
+)
+@click.option("--prod-semver-autoapprovals", callback=parse_semver_autoapprovals)
+@click.option("--dev-semver-autoapprovals", callback=parse_semver_autoapprovals)
+def main(
+    semver_level,
+    dependency_type,
+    prod_semver_autoapprovals,
+    dev_semver_autoapprovals,
+):
+    should_approve, review_message = review_pr(
+        dependency_type=dependency_type,
+        semver_level=semver_level,
+        prod_semver_autoapprovals=prod_semver_autoapprovals,
+        dev_semver_autoapprovals=dev_semver_autoapprovals,
+    )
+    set_output(
+        {
+            "should-approve": str(should_approve).lower(),
+            "review-message": review_message,
+        }
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds a custom action for automatically merging and approving Dependabot PRs. See #4 for motivation.

I've had a similar action running in https://github.com/grahamalama/dependabot-automerge-composite, and it's seemed to work as expected.

I'm not sure if 
```
uses: mozilla/syseng-pod/actions/dependabot-automerge
```
will work right out of the box. Unless y'all have other ideas, my plan was to "test this in production" by replacing the [JBI Dependabot workflow](https://github.com/mozilla/jira-bugzilla-integration/blob/main/.github/workflows/dependabot-automerge.yaml) with this and fixing errors as they pop up.

Closes #4 