### PR TITLE
Tweaks to Dependabot automerge action

### DIFF
--- a/actions/dependabot-automerge/README.md
+++ b/actions/dependabot-automerge/README.md
@@ -27,7 +27,7 @@ jobs:
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
       - name: Enable Dependabot automation
-        uses: mozilla/syseng-pod/actions/dependabot-automerge
+        uses: mozilla/syseng-pod/actions/dependabot-automerge@main
 ```
 
 the `contents` and `pull-requests` [token](https://docs.github.com/en/actions/security-guides/automatic-token-authentication) permissions (used by the action) need to be set to `write` so that the automation can leave comments, approve the PR, and enable auto-merge.

--- a/actions/dependabot-automerge/action.yml
+++ b/actions/dependabot-automerge/action.yml
@@ -30,7 +30,7 @@ runs:
       id: review-pr
       shell: bash
       run: |
-        python review_pr.py \
+        python $GITHUB_ACTION_PATH/review_pr.py \
           --semver-level "${{ steps.dependabot-metadata.outputs.update-type }}" \
           --dependency-type "${{ steps.dependabot-metadata.outputs.dependency-type }}" \
           --prod-semver-autoapprovals ${{ inputs.prod-semver-autoapprovals }} \


### PR DESCRIPTION
- add ref in example config for action
This is required when referring to an action path
- Use `$GITHUB_ACTION_PATH` as the parent of the pr review utility script
it seems like `${{ github.action_path }}` could be used as well, but there have been [some problems](https://github.com/actions/runner/issues/716#issuecomment-795238933) with that