### PR TITLE
Add `indirect` depedency type to review CLI 

### DIFF
--- a/actions/dependabot-automerge/review_pr.py
+++ b/actions/dependabot-automerge/review_pr.py
@@ -4,7 +4,8 @@ from enum import StrEnum, auto
 import click
 
 UPDATE_TYPE_PREFIX = "version-update:semver-"
-DEPENDENCY_TYPE_PREFIX = "direct:"
+DIRECT_DEPENDENCY_TYPE_PREFIX = "direct:"
+INDIRECT_DEPENDENCY_TYPE = "indirect"
 
 
 class DependencyType(StrEnum):
@@ -29,7 +30,7 @@ def parse_semver_level(ctx, option, value: str):
 
 
 def parse_dependency_type(ctx, option, value: str):
-    return DependencyType(value.removeprefix(DEPENDENCY_TYPE_PREFIX))
+    return DependencyType(value.removeprefix(DIRECT_DEPENDENCY_TYPE_PREFIX))
 
 
 def parse_semver_autoapprovals(ctx, option, value):
@@ -80,7 +81,10 @@ def review_pr(
 )
 @click.option(
     "--dependency-type",
-    type=click.Choice([DEPENDENCY_TYPE_PREFIX + e.value for e in DependencyType]),
+    type=click.Choice(
+        [INDIRECT_DEPENDENCY_TYPE]
+        + [DIRECT_DEPENDENCY_TYPE_PREFIX + e.value for e in DependencyType]
+    ),
     callback=parse_dependency_type,
 )
 @click.option("--prod-semver-autoapprovals", callback=parse_semver_autoapprovals)


### PR DESCRIPTION
[This PR](https://github.com/mozilla/jira-bugzilla-integration/actions/runs/5666989251/job/15354823190?pr=634) failed with:

```

Run python $GITHUB_ACTION_PATH/review_pr.py \
  python $GITHUB_ACTION_PATH/review_pr.py \
    --semver-level "version-update:semver-major" \
    --dependency-type "indirect" \
    --prod-semver-autoapprovals patch \
    --dev-semver-autoapprovals major,minor,patch
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    pythonLocation: /opt/hostedtoolcache/Python/3.11.4/x64
    PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.11.4/x64/lib/pkgconfig
    Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.4/x64
    Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.4/x64
    Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.4/x64
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.11.4/x64/lib
Usage: review_pr.py [OPTIONS]
Try 'review_pr.py --help' for help.

Error: Invalid value for '--dependency-type': 'indirect' is not one of 'direct:development', 'direct:production'.
Error: Process completed with exit code 2.
```