### PR TITLE
Turn quality standards and score cards into files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .venv/
 __pycache__
+docs/quality-standards/html/

--- a/docs/quality-standards/README.md
+++ b/docs/quality-standards/README.md
@@ -1,0 +1,29 @@
+# Quality Standards
+
+This folder is the source of https://mozilla.github.io/syseng-pod/quality-standards/
+
+
+## Audit projects
+
+Start or resume audit with:
+
+```
+./manage.py audit Socorro
+```
+
+And commit the changes to the `scorecards.yaml` file. 
+
+
+## Publish updates
+
+Generate the updated page locally, with the `quality-standards/` subfolder:
+
+```
+./manage.py html -o html/quality-standards/
+```
+
+Publish it to Github Pages using [ghp-import](https://pypi.org/project/ghp-import/):
+
+```
+ghp-import --push -m "Generate HTML page for quality standards" html/
+```

--- a/docs/quality-standards/criteria.yaml
+++ b/docs/quality-standards/criteria.yaml
@@ -36,7 +36,8 @@ standard:
             - bin/
         repo-readme-sections:
           description: |
-            - Readme contains the following:
+            Readme contains the following:
+
             - Project name as main title
             - Status (invest, sustain, sunset, abandoned)
             - Usage

--- a/docs/quality-standards/criteria.yaml
+++ b/docs/quality-standards/criteria.yaml
@@ -204,7 +204,7 @@ standard:
     - title: Documentation Content
       rules:
         documentation-decisions-records:
-          description: Enumerate evaluation criterias.
+          description: Enumerate evaluation criteria.
           details: Enumerate considered options with score/comment for each criteria.
         documentation-security-assessment:
           description: |

--- a/docs/quality-standards/criteria.yaml
+++ b/docs/quality-standards/criteria.yaml
@@ -131,6 +131,8 @@ standard:
           details: Eg. use poetry, cargo, …
 
     - title: Releasing
+      description: |
+        These checks apply to services that still rely on tags and releases. If a service has moved to *Continuous Delivery*, without tagging or releasing at all, they can all be considered as compliant.
       rules:
         release-semver-calver:
           description: Project follows SemVer or Calver version scheme

--- a/docs/quality-standards/criteria.yaml
+++ b/docs/quality-standards/criteria.yaml
@@ -27,9 +27,9 @@ standard:
             - SECURITY.md
             - SUPPORT.md
           details: |
-            See https://en.wikipedia.org/wiki/Contributing_guidelines
-            and https://mozillascience.github.io/working-open-workshop/contributing/
-            templates at https://contributing.md
+            See <https://en.wikipedia.org/wiki/Contributing_guidelines>
+            and <https://mozillascience.github.io/working-open-workshop/contributing/>
+            templates at <https://contributing.md>
         repo-standard-folders:
           description: |
             - docs/

--- a/docs/quality-standards/criteria.yaml
+++ b/docs/quality-standards/criteria.yaml
@@ -4,7 +4,7 @@ standard:
   description: |
     Hello, this doc is about explicitly defining quality in the world of services software at Mozilla.
 
-    Definition: quality refers to the degree to which a software and its related deliverables **meet or exceed** the **expectations** of its **stakeholders**. However, what are those expectations and does the team share the same expectations?  This document defines what the expectations are and provides a way to measure the quality of a software.
+    > Definition: quality refers to the degree to which a software and its related deliverables **meet or exceed** the **expectations** of its **stakeholders**. However, what are those expectations and does the team share the same expectations?  This document defines what the expectations are and provides a way to measure the quality of a software.
 
     Quality guarantees reliability and maintainability of the software, as well as efficiency of development.
 

--- a/docs/quality-standards/criterias.yaml
+++ b/docs/quality-standards/criterias.yaml
@@ -1,6 +1,12 @@
 ---
 standard:
-  description: Yeah
+  description: |
+    Hello, this doc is about explicitly defining quality in the world of services software at Mozilla.
+
+    Definition: quality refers to the degree to which a software and its related deliverables **meet or exceed** the **expectations** of its **stakeholders**. However, what are those expectations and does the team share the same expectations?  This document defines what the expectations are and provides a way to measure the quality of a software.
+
+    Quality guarantees reliability and maintainability of the software, as well as efficiency of development.
+
   categories:
     - title: Repository Ergonomics
       description: |

--- a/docs/quality-standards/criterias.yaml
+++ b/docs/quality-standards/criterias.yaml
@@ -1,5 +1,6 @@
 ---
 standard:
+  version: 1
   description: |
     Hello, this doc is about explicitly defining quality in the world of services software at Mozilla.
 

--- a/docs/quality-standards/criterias.yaml
+++ b/docs/quality-standards/criterias.yaml
@@ -1,3 +1,4 @@
+---
 standard:
   description: Yeah
   categories:
@@ -49,6 +50,78 @@ standard:
             - start
             - lint
             - format
+        repo-main-branch-name:
+          description: Main branch is called `main`
+        repo-main-branch-protected:
+          description: Main branch is protected without exceptions
+        repo-version-tags-protected:
+          description: Tags starting with `v*` can only be pushed by maintainers/admins
+          details: |
+            [Github docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-tag-protection-rules)
+        repo-issue-labels:
+          description: |
+            Standard issue labels exist:
+
+            - bug
+            - dependencies
+            - enhancement
+            - documentation
+            - wontfix
+            - good-first-issue
+        repo-team-reviewers-permissions:
+          description: Team of reviewers has at least “Maintain” permissions
+        repo-pull-request-merge:
+          description: Only “*squash and merge*” and “*rebase and merge*” are allowed
+        repo-pre-commit-optional:
+          description: Pre-commit hooks are optional
+          details: Example in [Taskcluster](https://github.com/taskcluster/taskcluster/blob/main/dev-docs/development-process.md#pre-commit-optional)
+
+    - title: Repository Automation
+      rules:
+        repo-release-notes-auto:
+          description: Release Notes are generated from commits using `.github/release.yml`
+          details: Sections titles contain at least “*Breaking changes*”, “*Bug fixes*”, “*New features*”, “*Documentation*”, and “*Other changes*”
+        repo-dependencies-auto:
+          description: Pull-requests are automatically opened for dependencies
+          details: File `.github/dependabot.yml` and/or `renovate.json` exist
+        repo-automerge-enabled:
+          description: Automerge and merge queues are enabled
+        repo-head-branch-auto-delete:
+          description: Auto-delete head branches is enabled
+        repo-code-owners:
+          description: Code owners are configured
+          details: At least with team of reviewers for everything (eg. @syseng-reviewers)
+
+    - title: Testing and linting
+      rules:
+        test-lint-secrets:
+          description: A test verifies that no secret is committed to the sources
+          details: Eg. [Yelp/detect-secrets](https://github.com/Yelp/detect-secrets)
+        test-lint-code-format:
+          description: A test verifies that code format respects standard
+          details: Eg. prettier, black+isort, cargo fmt
+        test-lint-static-analysis:
+          description: A test verifies that code respects idioms and good practices
+          details: Eg. eslint, bandit+pylint, cargo clippy
+        test-lint-type-checking:
+          description: A test verifies that types are used consistently
+          details: Eg. typescript, mypy
+        test-unit-coverage:
+          description: Unit tests fail if coverage is under 90%
+          details: Better if 100% with branching option
+        test-documentation-build:
+          description: A test verifies that documentation builds successfully without warnings
+          details: If the project does not have built documentation, a lint check for markdown files is recommended
+        test-container-build:
+          description: A test verifies that container builds successfully
+        test-container-integration:
+          description: A test executes integration tests on the built container
+        test-pull-requests-labels:
+          description: A test verifies that pull-requests have labels
+        dependencies-reproducibility:
+          description: Dependencies are locked between local clone, tests, and container
+          details: Eg. use poetry, cargo, …
+
     - title: Releasing
       rules:
         release-semver-calver:
@@ -63,3 +136,80 @@ standard:
             Does not apply to libraries, where a version number usually appears in package metadata
         release-publish:
           description: Project container or package is published on git tag
+
+    - title: Deployment
+      rules:
+        deployment-dockerflow:
+          description: Container follows Dockerflow spec
+        deployment-integration-test:
+          description: Integration tests are part of deployment pipeline
+          details: Might be as well end-to-end (browser tests)
+        deployment-auto-main:
+          description: Automatic deployment on DEV/STAGE environment on pull-requests merge
+        deployment-auto-release:
+          description: Automatic deployment on STAGE/PROD environment on version tag
+          details: If they pass through a quality gate like an automated integration test
+        deployment-auto-pull-requests:
+          description: Automatic deployment on temporary instances on pull-requests
+          details: Should be allowed to repo owners only?
+
+    - title: Monitoring
+      rules:
+        monitoring-heartbeat-backends:
+          description: Heartbeat endpoint checks that backends can executed desired operations (eg. DB, cache, filesystem etc.) to support troubleshooting
+        monitoring-heartbeat-error:
+          description: Heartbeat checks throw errors that will be reported
+        monitoring-requests-duration:
+          description: API requests processing duration is monitored
+        monitoring-requests-id:
+          description: A unique ID is associated to each request and logged
+        monitoring-backends-duration:
+          description: Backends calls durations are monitored
+          details: |
+            [Existing standards](https://opentelemetry.io/docs/concepts/signals/traces/)
+        monitoring-logging-level:
+          description: Logging has INFO level by default
+        monitoring-logging-mozlog:
+          description: Logging format is MozLog by default
+        monitoring-logging-env-configuration:
+          description: Logging level is set using `LOG_LEVEL` env variable. Logging format is set using `LOG_FORMAT` env variable
+        monitoring-error-reporting:
+          description: Sentry is setup by environment
+
+    - title: Telemetry
+      rules:
+        telemetry-metrics:
+          description: Project sends live telemetry
+          details: StatsD with tags
+        telemetry-naming:
+          description: Probes start with project name (eg. `ctms.*`)
+        telemetry-documented:
+          description: Probes are listed in documentation
+        telemetry-query-examples:
+          description: BigQuery example queries are given in documentation
+
+    - title: Notifications
+      rules:
+        notifications-error-chat:
+          description: Sentry reports to Slack channel
+          details: Sentry creates Github issues?
+
+    - title: Documentation Content
+      rules:
+        documentation-decisions-records:
+          description: Enumerate evaluation criterias.
+          details: Enumerate considered options with score/comment for each criteria.
+        documentation-security-assessment:
+          description: |
+            [Rapid Risk Assessment](https://infosec.mozilla.org/guidelines/risk/rapid_risk_assessment), either a link or its content
+        documentation-dev:
+          description: |
+            Instructions for a developper: how to run the tests, procedures to obtain credentials on dev/stage instances, contribute, contact the team, etc.
+        documentation-test-args:
+          description: Instructions on how to run test suite with custom arguments (eg. test selection, verbosity, etc.)
+        documentation-operator:
+          description: |
+            Instructions for an operator: how to deploy and run the application, how to configure it for production, etc.
+          details: Can also be called “Deployment docs”
+        documentation-troubleshooting:
+          description: Common troubleshooting steps

--- a/docs/quality-standards/criterias.yaml
+++ b/docs/quality-standards/criterias.yaml
@@ -1,0 +1,65 @@
+standard:
+  description: Yeah
+  categories:
+    - title: Repository Ergonomics
+      description: |
+        > Ergonomics *(ûr″gə-nŏm′ĭks)*: Design factors, as for the workplace, intended to maximize productivity by minimizing operator fatigue and discomfort.
+
+        * It takes time and effort to learn a project’s repository layout.
+        * How a project repository is organized provides little return on the mental energy it takes to learn it
+        * To contribute to a project someone is required to learn how its content is organized.
+        * There is too little reusable knowledge across project organizations / layouts
+      rules:
+        repo-standard-files:
+          description: |
+            - README.(md,rst)
+            - LICENSE
+            - CODE_OF_CONDUCT.md
+            - CONTRIBUTING.md
+            - SECURITY.md
+            - SUPPORT.md
+          details: |
+            See https://en.wikipedia.org/wiki/Contributing_guidelines
+            and https://mozillascience.github.io/working-open-workshop/contributing/
+            templates at https://contributing.md
+        repo-standard-folders:
+          description: |
+            - docs/
+            - bin/
+        repo-readme-sections:
+          description: |
+            - Readme contains the following:
+            - Project name as main title
+            - Status (invest, sustain, sunset, abandoned)
+            - Usage
+            - Link to documentation
+          details: |
+            Our goals here are:
+
+            - avoid empty README
+            - expose maintenance status
+            - basic usage is detailed
+            - standard sections will help reading/scanning for newcomers
+        repo-makefile-targets:
+          description: |
+            Make has the following targets:
+
+            - help
+            - test
+            - start
+            - lint
+            - format
+    - title: Releasing
+      rules:
+        release-semver-calver:
+          description: Project follows SemVer or Calver version scheme
+        release-tag-v-prefix:
+          description: The release tags have `v(.+)` format
+        release-tag-only:
+          description: |
+            Project version has a single source of truth. For example, it is read from `version.json`
+            which is automatically built from current git tag
+          details:
+            Does not apply to libraries, where a version number usually appears in package metadata
+        release-publish:
+          description: Project container or package is published on git tag

--- a/docs/quality-standards/manage.py
+++ b/docs/quality-standards/manage.py
@@ -25,7 +25,10 @@ def cli():
 @cli.command()
 def html():
     with open("criteria.yaml") as f:
-        root = ruamel.yaml.load(f, Loader=ruamel.yaml.Loader)
+        root_criteria = ruamel.yaml.load(f, Loader=ruamel.yaml.Loader)
+
+    with open("scorecards.yaml") as f:
+        root_scorecards = ruamel.yaml.load(f, Loader=ruamel.yaml.Loader)
 
     def render_markdown(value):
         return markdown.markdown(value)
@@ -36,7 +39,7 @@ def html():
     env.filters["markdown"] = render_markdown
 
     template = env.get_template("template.html")
-    context = {"standard": root["standard"]}
+    context = {"standard": root_criteria["standard"], "scorecards": root_scorecards}
     rendered = template.render(**context)
 
     os.makedirs("html", exist_ok=True)

--- a/docs/quality-standards/manage.py
+++ b/docs/quality-standards/manage.py
@@ -1,0 +1,99 @@
+#! /usr/bin/env python3
+import datetime
+import os
+import sys
+
+try:
+    import click
+    import markdown
+    import questionary
+    import ruamel.yaml
+    import jinja2
+except ImportError as e:
+    print(
+        f"Python package(s) missing ({e}). Install them with:\n\npip install -r requirements.txt"
+    )
+    sys.exit(2)
+
+
+@click.group()
+def cli():
+    pass
+
+
+@cli.command()
+def html():
+    with open("criterias.yaml") as f:
+        root = ruamel.yaml.load(f, Loader=ruamel.yaml.Loader)
+
+    def render_markdown(value):
+        return markdown.markdown(value)
+
+    env = jinja2.Environment(
+        loader=jinja2.FileSystemLoader("."),
+    )
+    env.filters["markdown"] = render_markdown
+
+    template = env.get_template("template.html")
+    context = {"standard": root["standard"]}
+    rendered = template.render(**context)
+
+    os.makedirs("html", exist_ok=True)
+    output = os.path.abspath(os.path.join("html", "index.html"))
+    with open(output, "w") as f:
+        f.write(rendered)
+    click.echo(f"Rendered {output}")
+
+
+@cli.command()
+def audit():
+    criteria = os.path.join(os.path.dirname(__file__), "criterias.yaml")
+    with open(criteria) as f:
+        root = ruamel.yaml.load(f, Loader=ruamel.yaml.Loader)
+
+    service = questionary.text("What is the service name?").ask()
+
+    points_for = {
+        "Yes": 2,
+        "Partially": 1,
+        "No": 0,
+    }
+    max_score = 0
+    score_card = []
+    for category in root["standard"]["categories"]:
+        for name, rule in category["rules"].items():
+            score_card.append(
+                {
+                    "type": "select",
+                    "name": name,
+                    "message": f"{name} ?",
+                    "choices": points_for.keys(),
+                }
+            )
+            max_score += 2
+
+    answers = questionary.prompt(score_card)
+
+    score = 100 * sum(points_for[v] for v in answers.values()) / max_score
+    click.echo(f"Service score is {score}")
+
+    # Save score cards
+    yaml = ruamel.yaml.YAML()
+    output = f"scorecards-{service}.yaml"
+    try:
+        with open(output) as existing:
+            scorecards = yaml.load(existing)
+    except IOError:
+        scorecards = {}
+    today = datetime.date.today().isoformat()
+    scorecards[today] = {
+        "score": score,
+        "rules": answers,
+    }
+    with open(output, "w") as out:
+        yaml.dump(scorecards, out)
+    click.echo(f"Rendered {output}")
+
+
+if __name__ == "__main__":
+    cli(obj={})

--- a/docs/quality-standards/manage.py
+++ b/docs/quality-standards/manage.py
@@ -68,6 +68,7 @@ def audit():
                     "name": name,
                     "message": f"{name} ?",
                     "choices": points_for.keys(),
+                    "instruction": "\n" + rule["description"].strip() + "\n",
                 }
             )
             max_score += 2

--- a/docs/quality-standards/manage.py
+++ b/docs/quality-standards/manage.py
@@ -45,7 +45,11 @@ def html(output):
     env.filters["markdown"] = render_markdown
 
     template = env.get_template("template.html")
-    context = {"standard": root_criteria["standard"], "scorecards": root_scorecards}
+    context = {
+        "standard": root_criteria["standard"],
+        "scorecards": root_scorecards,
+        "criteria_last_update": datetime.datetime.fromtimestamp(os.path.getmtime("criteria.yaml")),
+    }
     rendered = template.render(**context)
 
     os.makedirs(output, exist_ok=True)

--- a/docs/quality-standards/manage.py
+++ b/docs/quality-standards/manage.py
@@ -24,7 +24,7 @@ def cli():
 
 @cli.command()
 def html():
-    with open("criterias.yaml") as f:
+    with open("criteria.yaml") as f:
         root = ruamel.yaml.load(f, Loader=ruamel.yaml.Loader)
 
     def render_markdown(value):
@@ -54,7 +54,7 @@ def html():
 def audit(service):
     from questionary.prompts.common import print_formatted_text
 
-    criteria = os.path.join(os.path.dirname(__file__), "criterias.yaml")
+    criteria = os.path.join(os.path.dirname(__file__), "criteria.yaml")
     with open(criteria) as f:
         root = ruamel.yaml.load(f, Loader=ruamel.yaml.Loader)
 

--- a/docs/quality-standards/manage.py
+++ b/docs/quality-standards/manage.py
@@ -75,6 +75,7 @@ def audit(service):
         "Yes": 2,
         "Partially": 1,
         "No": 0,
+        "Unknown": 0,
     }
 
     max_score = 0

--- a/docs/quality-standards/manage.py
+++ b/docs/quality-standards/manage.py
@@ -23,7 +23,13 @@ def cli():
 
 
 @cli.command()
-def html():
+@click.option(
+    "-o",
+    "--output",
+    help="Destination folder",
+    default="html"
+)
+def html(output):
     with open("criteria.yaml") as f:
         root_criteria = ruamel.yaml.load(f, Loader=ruamel.yaml.Loader)
 
@@ -42,11 +48,11 @@ def html():
     context = {"standard": root_criteria["standard"], "scorecards": root_scorecards}
     rendered = template.render(**context)
 
-    os.makedirs("html", exist_ok=True)
-    output = os.path.abspath(os.path.join("html", "index.html"))
-    with open(output, "w") as f:
+    os.makedirs(output, exist_ok=True)
+    output_index = os.path.abspath(os.path.join(output, "index.html"))
+    with open(output_index, "w") as f:
         f.write(rendered)
-    click.echo(f"Rendered {output}")
+    click.echo(f"Rendered {output_index}")
 
 
 @cli.command()

--- a/docs/quality-standards/requirements.txt
+++ b/docs/quality-standards/requirements.txt
@@ -1,0 +1,5 @@
+click==8.*
+markdown==3.*
+questionary==2.*
+ruamel.yaml==0.17.*
+Jinja2==3.*

--- a/docs/quality-standards/scorecards.yaml
+++ b/docs/quality-standards/scorecards.yaml
@@ -1,0 +1,114 @@
+ctms:
+  '2023-09-01':
+    version: 1
+    score: 64
+    max_score: 110
+    rules:
+      repo-standard-files:
+        compliant: Yes
+        notes: ''
+      repo-standard-folders:
+        compliant: Yes
+        notes: ''
+      repo-readme-sections:
+        compliant: Yes
+        notes: ''
+      repo-makefile-targets:
+        compliant: Yes
+        notes: ''
+      repo-main-branch-name:
+        compliant: Yes
+        notes: ''
+      repo-main-branch-protected:
+        compliant: Yes
+        notes: ''
+      repo-version-tags-protected:
+        compliant: Yes
+        notes: ''
+      repo-issue-labels:
+        compliant: Yes
+        notes: ''
+      repo-team-reviewers-permissions:
+        compliant: Yes
+        notes: ''
+      repo-pull-request-merge:
+        compliant: Yes
+        notes: ''
+      repo-pre-commit-optional:
+        compliant: Yes
+        notes: ''
+      repo-release-notes-auto:
+        compliant: Yes
+        notes: ''
+      repo-dependencies-auto:
+        compliant: Yes
+        notes: ''
+      repo-automerge-enabled:
+        compliant: Yes
+        notes: ''
+      repo-head-branch-auto-delete:
+        compliant: Yes
+        notes: ''
+      repo-code-owners:
+        compliant: Yes
+        notes: ''
+      test-lint-secrets:
+        compliant: Yes
+        notes: ''
+      test-lint-code-format:
+        compliant: Yes
+        notes: ''
+      test-lint-static-analysis:
+        compliant: Yes
+        notes: ''
+      test-lint-type-checking:
+        compliant: Yes
+        notes: ''
+      test-unit-coverage:
+        compliant: Yes
+        notes: ''
+      test-documentation-build:
+        compliant: No
+        notes: Docs are only markdown files
+      test-container-build:
+        compliant: Yes
+        notes: ''
+      test-container-integration:
+        compliant: No
+        notes: ''
+      test-pull-requests-labels:
+        compliant: Yes
+        notes: ''
+      dependencies-reproducibility:
+        compliant: Yes
+        notes: ''
+      release-semver-calver:
+        compliant: Yes
+        notes: ''
+      release-tag-v-prefix:
+        compliant: Yes
+        notes: ''
+      release-tag-only:
+        compliant: Yes
+        notes: ''
+      release-publish:
+        compliant: Yes
+        notes: ''
+      deployment-dockerflow:
+        compliant: Yes
+        notes: ''
+      deployment-integration-test:
+        compliant: No
+        notes: ''
+      deployment-auto-main:
+        compliant: Yes
+        notes: ''
+      deployment-auto-release:
+        compliant: Yes
+        notes: ''
+      deployment-auto-pull-requests:
+        compliant: No
+        notes: ''
+      monitoring-heartbeat-backends:
+        compliant: Yes
+        notes: ''

--- a/docs/quality-standards/scorecards.yaml
+++ b/docs/quality-standards/scorecards.yaml
@@ -858,7 +858,7 @@ Remote Settings:
         compliant: Yes
   '2023-09-04':
     version: 1
-    score: 94
+    score: 92
     max_score: 110
     rules:
       repo-standard-folders:
@@ -948,7 +948,7 @@ Remote Settings:
       test-pull-requests-labels:
         compliant: Yes
       release-tag-v-prefix:
-        compliant: Yes
+        compliant: No
       release-tag-only:
         compliant: Yes
       deployment-integration-test:

--- a/docs/quality-standards/scorecards.yaml
+++ b/docs/quality-standards/scorecards.yaml
@@ -1,114 +1,973 @@
-ctms:
-  '2023-09-01':
+CTMS:
+  '2023-06-30':
     version: 1
-    score: 64
+    score: 89
     max_score: 110
     rules:
       repo-standard-files:
         compliant: Yes
-        notes: ''
       repo-standard-folders:
         compliant: Yes
-        notes: ''
       repo-readme-sections:
         compliant: Yes
-        notes: ''
       repo-makefile-targets:
         compliant: Yes
-        notes: ''
       repo-main-branch-name:
         compliant: Yes
-        notes: ''
       repo-main-branch-protected:
         compliant: Yes
-        notes: ''
       repo-version-tags-protected:
         compliant: Yes
-        notes: ''
       repo-issue-labels:
         compliant: Yes
-        notes: ''
       repo-team-reviewers-permissions:
         compliant: Yes
-        notes: ''
       repo-pull-request-merge:
         compliant: Yes
-        notes: ''
       repo-pre-commit-optional:
         compliant: Yes
-        notes: ''
       repo-release-notes-auto:
         compliant: Yes
-        notes: ''
       repo-dependencies-auto:
         compliant: Yes
-        notes: ''
       repo-automerge-enabled:
         compliant: Yes
-        notes: ''
       repo-head-branch-auto-delete:
         compliant: Yes
-        notes: ''
       repo-code-owners:
         compliant: Yes
-        notes: ''
       test-lint-secrets:
         compliant: Yes
-        notes: ''
       test-lint-code-format:
         compliant: Yes
-        notes: ''
       test-lint-static-analysis:
         compliant: Yes
-        notes: ''
       test-lint-type-checking:
         compliant: Yes
-        notes: ''
       test-unit-coverage:
         compliant: Yes
-        notes: ''
       test-documentation-build:
-        compliant: No
+        compliant: Partially
         notes: Docs are only markdown files
       test-container-build:
         compliant: Yes
-        notes: ''
       test-container-integration:
-        compliant: No
-        notes: ''
+        compliant: Yes
       test-pull-requests-labels:
         compliant: Yes
-        notes: ''
       dependencies-reproducibility:
         compliant: Yes
-        notes: ''
       release-semver-calver:
         compliant: Yes
-        notes: ''
       release-tag-v-prefix:
         compliant: Yes
-        notes: ''
       release-tag-only:
         compliant: Yes
-        notes: ''
       release-publish:
         compliant: Yes
-        notes: ''
       deployment-dockerflow:
         compliant: Yes
-        notes: ''
+      deployment-integration-test:
+        compliant: No
+      deployment-auto-main:
+        compliant: Yes
+      deployment-auto-release:
+        compliant: Yes
+      deployment-auto-pull-requests:
+        compliant: No
+      monitoring-heartbeat-backends:
+        compliant: Yes
+      monitoring-backends-duration:
+        compliant: Yes
+      monitoring-logging-env-configuration:
+        compliant: Partially
+        notes: USE_MOZLOG instead of LOG_FORMAT, LOGGING_LEVEL instead of LOG_LEVEL
+      monitoring-heartbeat-error:
+        compliant: Yes
+      monitoring-requests-duration:
+        compliant: Yes
+      monitoring-requests-id:
+        compliant: Yes
+      monitoring-logging-level:
+        compliant: Yes
+      monitoring-logging-mozlog:
+        compliant: Yes
+      monitoring-error-reporting:
+        compliant: Yes
+      telemetry-metrics:
+        compliant: Yes
+      telemetry-naming:
+        compliant: Yes
+      telemetry-documented:
+        compliant: Yes
+      telemetry-query-examples:
+        compliant: Yes
+      notifications-error-chat:
+        compliant: Yes
+      documentation-decisions-records:
+        compliant: Yes
+      documentation-security-assessment:
+        compliant: No
+      documentation-dev:
+        compliant: Yes
+      documentation-test-args:
+        compliant: Yes
+      documentation-operator:
+        compliant: Yes
+      documentation-troubleshooting:
+        compliant: No
+  '2023-02-01':
+    version: 1
+    score: 80
+    max_score: 110
+    rules:
+      repo-standard-files:
+        compliant: No
+        notes: Missing CODE_OF_CONDUCT.md, CONTRIBUTING.md, SECURITY.md
+      repo-standard-folders:
+        compliant: Yes
+      repo-readme-sections:
+        compliant: No
+        notes: README has only links to `docs/`
+      repo-makefile-targets:
+        compliant: Yes
+      repo-main-branch-name:
+        compliant: Yes
+      repo-main-branch-protected:
+        compliant: Yes
+      repo-version-tags-protected:
+        compliant: Yes
+      repo-issue-labels:
+        compliant: Yes
+      repo-team-reviewers-permissions:
+        compliant: Yes
+      repo-pull-request-merge:
+        compliant: Yes
+      repo-pre-commit-optional:
+        compliant: Yes
+      repo-release-notes-auto:
+        compliant: Yes
+      repo-dependencies-auto:
+        compliant: Yes
+      repo-automerge-enabled:
+        compliant: Yes
+      repo-head-branch-auto-delete:
+        compliant: Yes
+      repo-code-owners:
+        compliant: Yes
+      test-lint-secrets:
+        compliant: Yes
+      test-lint-code-format:
+        compliant: Yes
+      test-lint-static-analysis:
+        compliant: Yes
+      test-lint-type-checking:
+        compliant: Yes
+      test-unit-coverage:
+        compliant: Yes
+      test-documentation-build:
+        compliant: Partially
+        notes: Docs are only markdown files
+      test-container-build:
+        compliant: Yes
+      test-container-integration:
+        compliant: Yes
+      test-pull-requests-labels:
+        compliant: Yes
+      dependencies-reproducibility:
+        compliant: Yes
+      release-semver-calver:
+        compliant: Yes
+      release-tag-v-prefix:
+        compliant: Yes
+      release-tag-only:
+        compliant: Yes
+      release-publish:
+        compliant: Yes
+      deployment-dockerflow:
+        compliant: Yes
+      deployment-integration-test:
+        compliant: No
+      deployment-auto-main:
+        compliant: Yes
+      deployment-auto-release:
+        compliant: Yes
+      deployment-auto-pull-requests:
+        compliant: No
+      monitoring-heartbeat-backends:
+        compliant: Yes
+      monitoring-backends-duration:
+        compliant: Yes
+      monitoring-logging-env-configuration:
+        compliant: Partially
+        notes: USE_MOZLOG instead of LOG_FORMAT, LOGGING_LEVEL instead of LOG_LEVEL
+      monitoring-heartbeat-error:
+        compliant: Yes
+      monitoring-requests-duration:
+        compliant: No
+      monitoring-requests-id:
+        compliant: Yes
+      monitoring-logging-level:
+        compliant: Yes
+      monitoring-logging-mozlog:
+        compliant: Yes
+      monitoring-error-reporting:
+        compliant: Yes
+      telemetry-metrics:
+        compliant: Yes
+      telemetry-naming:
+        compliant: Yes
+      telemetry-documented:
+        compliant: Yes
+      telemetry-query-examples:
+        compliant: No
+        notes: Until now, logs/metrics are not easily accessible
+      notifications-error-chat:
+        compliant: Yes
+      documentation-decisions-records:
+        compliant: Yes
+      documentation-security-assessment:
+        compliant: No
+      documentation-dev:
+        compliant: Yes
+      documentation-test-args:
+        compliant: No
+      documentation-operator:
+        compliant: Yes
+      documentation-troubleshooting:
+        compliant: No
+JBI:
+  '2023-02-04':
+    version: 1
+    score: 86
+    max_score: 110
+    rules:
+      repo-standard-files:
+        compliant: No
+        notes: No LICENSE, CONTRIBUTING, files
+      repo-standard-folders:
+        compliant: No
+        notes: 'No docs/ folder, bin/ instead of scripts/ '
+      repo-readme-sections:
+        compliant: No
+        notes: No status section in readme
+      repo-makefile-targets:
+        compliant: No
+        notes: No make clean
+      repo-main-branch-name:
+        compliant: Yes
+      repo-main-branch-protected:
+        compliant: Yes
+      repo-version-tags-protected:
+        compliant: Yes
+      repo-issue-labels:
+        compliant: Yes
+      repo-team-reviewers-permissions:
+        compliant: Yes
+      repo-pull-request-merge:
+        compliant: Yes
+      repo-pre-commit-optional:
+        compliant: Yes
+      repo-release-notes-auto:
+        compliant: Yes
+      repo-dependencies-auto:
+        compliant: Yes
+      repo-automerge-enabled:
+        compliant: Yes
+      repo-head-branch-auto-delete:
+        compliant: Yes
+      repo-code-owners:
+        compliant: Yes
+      test-lint-secrets:
+        compliant: Yes
+      test-lint-code-format:
+        compliant: Yes
+      test-lint-static-analysis:
+        compliant: Yes
+      test-lint-type-checking:
+        compliant: Yes
+      test-unit-coverage:
+        compliant: Yes
+      test-documentation-build:
+        compliant: Partially
+        notes: No built documentation, no markdown lint
+      test-container-build:
+        compliant: Yes
+      test-container-integration:
+        compliant: No
+        notes: Built container is not tested
+      test-pull-requests-labels:
+        compliant: Yes
+      dependencies-reproducibility:
+        compliant: Yes
+      release-semver-calver:
+        compliant: Yes
+      release-tag-v-prefix:
+        compliant: Yes
+      release-tag-only:
+        compliant: Yes
+      release-publish:
+        compliant: Yes
+      deployment-dockerflow:
+        compliant: Yes
+      deployment-integration-test:
+        compliant: No
+        notes: No integration test available.
+      deployment-auto-main:
+        compliant: Yes
+      deployment-auto-release:
+        compliant: Yes
+      deployment-auto-pull-requests:
+        compliant: No
+        notes: No temporary instance deployed on pull-requests. THis would improve
+          productivity since we could test configuration changes before merging/deploying
+          to STAGE.
+      monitoring-heartbeat-backends:
+        compliant: Yes
+      monitoring-heartbeat-error:
+        compliant: Yes
+      monitoring-requests-duration:
+        compliant: Yes
+      monitoring-requests-id:
+        compliant: Yes
+      monitoring-backends-duration:
+        compliant: Yes
+      monitoring-logging-level:
+        compliant: No
+        notes: DEBUG by default instead of INFO
+      monitoring-logging-mozlog:
+        compliant: Partially
+        notes: Log level via LOG_LEVEL but log format is not configurable.
+      monitoring-logging-env-configuration:
+        compliant: Yes
+      monitoring-error-reporting:
+        compliant: Yes
+      telemetry-metrics:
+        compliant: Yes
+      telemetry-naming:
+        compliant: Yes
+      telemetry-documented:
+        compliant: Yes
+      telemetry-query-examples:
+        compliant: Yes
+      notifications-error-chat:
+        compliant: Yes
+      documentation-decisions-records:
+        compliant: No
+      documentation-security-assessment:
+        compliant: No
+        notes: No link to RRA.
+      documentation-dev:
+        compliant: Yes
+      documentation-test-args:
+        compliant: No
+      documentation-operator:
+        compliant: Yes
+      documentation-troubleshooting:
+        compliant: Yes
+  '2023-07-04':
+    version: 1
+    score: 105
+    max_score: 110
+    rules:
+      repo-main-branch-name:
+        compliant: Yes
+      repo-main-branch-protected:
+        compliant: Yes
+      repo-version-tags-protected:
+        compliant: Yes
+      repo-issue-labels:
+        compliant: Yes
+      repo-team-reviewers-permissions:
+        compliant: Yes
+      repo-pull-request-merge:
+        compliant: Yes
+      repo-pre-commit-optional:
+        compliant: Yes
+      repo-release-notes-auto:
+        compliant: Yes
+      repo-dependencies-auto:
+        compliant: Yes
+      repo-automerge-enabled:
+        compliant: Yes
+      repo-head-branch-auto-delete:
+        compliant: Yes
+      repo-code-owners:
+        compliant: Yes
+      test-lint-secrets:
+        compliant: Yes
+      test-lint-code-format:
+        compliant: Yes
+      test-lint-static-analysis:
+        compliant: Yes
+      test-lint-type-checking:
+        compliant: Yes
+      test-unit-coverage:
+        compliant: Yes
+      test-container-build:
+        compliant: Yes
+      test-pull-requests-labels:
+        compliant: Yes
+      dependencies-reproducibility:
+        compliant: Yes
+      release-semver-calver:
+        compliant: Yes
+      release-tag-v-prefix:
+        compliant: Yes
+      release-tag-only:
+        compliant: Yes
+      release-publish:
+        compliant: Yes
+      deployment-dockerflow:
+        compliant: Yes
+      deployment-auto-main:
+        compliant: Yes
+      deployment-auto-release:
+        compliant: Yes
+      monitoring-heartbeat-backends:
+        compliant: Yes
+      monitoring-heartbeat-error:
+        compliant: Yes
+      monitoring-requests-duration:
+        compliant: Yes
+      monitoring-requests-id:
+        compliant: Yes
+      monitoring-backends-duration:
+        compliant: Yes
+      monitoring-logging-env-configuration:
+        compliant: Yes
+      monitoring-error-reporting:
+        compliant: Yes
+      telemetry-metrics:
+        compliant: Yes
+      telemetry-naming:
+        compliant: Yes
+      telemetry-documented:
+        compliant: Yes
+      telemetry-query-examples:
+        compliant: Yes
+      notifications-error-chat:
+        compliant: Yes
+      documentation-dev:
+        compliant: Yes
+      documentation-operator:
+        compliant: Yes
+      documentation-troubleshooting:
+        compliant: Yes
+      repo-standard-files:
+        compliant: Yes
+      repo-standard-folders:
+        compliant: Yes
+      repo-readme-sections:
+        compliant: Yes
+      repo-makefile-targets:
+        compliant: Yes
+      test-documentation-build:
+        compliant: Partially
+      test-container-integration:
+        compliant: Yes
+      deployment-integration-test:
+        compliant: No
+      deployment-auto-pull-requests:
+        compliant: No
+      monitoring-logging-level:
+        compliant: Yes
+      monitoring-logging-mozlog:
+        compliant: Yes
+      documentation-decisions-records:
+        compliant: Yes
+      documentation-security-assessment:
+        compliant: Yes
+      documentation-test-args:
+        compliant: Yes
+Telescope:
+  '2023-01-01':
+    version: 1
+    score: 78
+    max_score: 110
+    rules:
+      repo-standard-files:
+        compliant: No
+        notes: Missing CODE_OF_CONDUCT.md, CONTRIBUTING.md, SECURITY.md
+      repo-standard-folders:
+        compliant: No
+        notes: scripts/ instead of bin/
+      repo-readme-sections:
+        compliant: Partially
+        notes: Missing status badge, documentation within README
+      repo-makefile-targets:
+        compliant: No
+        notes: Missing help, serve instead of start
+      repo-main-branch-name:
+        compliant: Yes
+      repo-main-branch-protected:
+        compliant: Yes
+      repo-version-tags-protected:
+        compliant: Yes
+      repo-issue-labels:
+        compliant: Yes
+      repo-team-reviewers-permissions:
+        compliant: Yes
+      repo-pull-request-merge:
+        compliant: Yes
+      repo-pre-commit-optional:
+        compliant: Yes
+      repo-release-notes-auto:
+        compliant: Yes
+      repo-dependencies-auto:
+        compliant: Yes
+      repo-automerge-enabled:
+        compliant: Yes
+      repo-head-branch-auto-delete:
+        compliant: Yes
+      repo-code-owners:
+        compliant: Yes
+      test-lint-secrets:
+        compliant: No
+      test-lint-code-format:
+        compliant: Yes
+      test-lint-static-analysis:
+        compliant: Yes
+      test-lint-type-checking:
+        compliant: Yes
+      test-unit-coverage:
+        compliant: Yes
+      test-documentation-build:
+        compliant: Partially
+      test-container-build:
+        compliant: Yes
+      test-container-integration:
+        compliant: Partially
+        notes: No integration tests (Telescope has no backend)
+      test-pull-requests-labels:
+        compliant: Yes
+      dependencies-reproducibility:
+        compliant: Yes
+      release-semver-calver:
+        compliant: Yes
+      release-tag-v-prefix:
+        compliant: Yes
+      release-tag-only:
+        compliant: Yes
+      release-publish:
+        compliant: Yes
+      deployment-dockerflow:
+        compliant: Yes
       deployment-integration-test:
         compliant: No
         notes: ''
       deployment-auto-main:
         compliant: Yes
-        notes: ''
       deployment-auto-release:
         compliant: Yes
-        notes: ''
       deployment-auto-pull-requests:
         compliant: No
-        notes: ''
+        notes: No DEV environment and no temporary instance deployed on pull-requests.
+      monitoring-heartbeat-backends:
+        compliant: Partially
+        notes: No backend
+      monitoring-heartbeat-error:
+        compliant: Partially
+        notes: No check in heartbeat
+      monitoring-requests-duration:
+        compliant: Yes
+      monitoring-requests-id:
+        compliant: No
+      monitoring-backends-duration:
+        compliant: Partially
+        notes: No backend
+      monitoring-logging-level:
+        compliant: Yes
+      monitoring-logging-mozlog:
+        compliant: Yes
+      monitoring-logging-env-configuration:
+        compliant: Yes
+      monitoring-error-reporting:
+        compliant: Yes
+      telemetry-metrics:
+        compliant: No
+        notes: No telemetry
+      telemetry-naming:
+        compliant: Partially
+        notes: No telemetry
+      telemetry-documented:
+        compliant: Partially
+        notes: No telemetry
+      telemetry-query-examples:
+        compliant: Partially
+        notes: No telemetry
+      notifications-error-chat:
+        compliant: No
+        notes: Would be too verbose
+      documentation-decisions-records:
+        compliant: Yes
+      documentation-security-assessment:
+        compliant: No
+      documentation-dev:
+        compliant: Yes
+      documentation-test-args:
+        compliant: No
+      documentation-operator:
+        compliant: Partially
+        notes: Only configuration
+      documentation-troubleshooting:
+        compliant: Partially
+        notes: Troubleshooting docs are on Mana but not about Telescope itself
+  '2023-09-04':
+    version: 1
+    score: 93
+    max_score: 110
+    rules:
+      repo-main-branch-name:
+        compliant: Yes
+      repo-main-branch-protected:
+        compliant: Yes
+      repo-version-tags-protected:
+        compliant: Yes
+      repo-issue-labels:
+        compliant: Yes
+      repo-team-reviewers-permissions:
+        compliant: Yes
+      repo-pull-request-merge:
+        compliant: Yes
+      repo-pre-commit-optional:
+        compliant: Yes
+      repo-release-notes-auto:
+        compliant: Yes
+      repo-dependencies-auto:
+        compliant: Yes
+      repo-automerge-enabled:
+        compliant: Yes
+      repo-head-branch-auto-delete:
+        compliant: Yes
+      repo-code-owners:
+        compliant: Yes
+      test-lint-code-format:
+        compliant: Yes
+      test-lint-static-analysis:
+        compliant: Yes
+      test-lint-type-checking:
+        compliant: Yes
+      test-unit-coverage:
+        compliant: Yes
+      test-documentation-build:
+        compliant: Partially
+      test-container-build:
+        compliant: Yes
+      test-pull-requests-labels:
+        compliant: Yes
+      dependencies-reproducibility:
+        compliant: Yes
+      release-semver-calver:
+        compliant: Yes
+      release-tag-v-prefix:
+        compliant: Yes
+      release-tag-only:
+        compliant: Yes
+      release-publish:
+        compliant: Yes
+      deployment-dockerflow:
+        compliant: Yes
+      deployment-auto-main:
+        compliant: Yes
+      deployment-auto-release:
+        compliant: Yes
+      monitoring-requests-duration:
+        compliant: Yes
+      monitoring-logging-level:
+        compliant: Yes
+      monitoring-logging-mozlog:
+        compliant: Yes
+      monitoring-logging-env-configuration:
+        compliant: Yes
+      monitoring-error-reporting:
+        compliant: Yes
+      documentation-decisions-records:
+        compliant: Yes
+      documentation-dev:
+        compliant: Yes
+      repo-standard-files:
+        compliant: Yes
+      repo-standard-folders:
+        compliant: Yes
+      repo-readme-sections:
+        compliant: Yes
+      repo-makefile-targets:
+        compliant: Yes
+      test-lint-secrets:
+        compliant: Yes
+      test-container-integration:
+        compliant: Partially
+      deployment-integration-test:
+        compliant: No
+      deployment-auto-pull-requests:
+        compliant: Partially
       monitoring-heartbeat-backends:
         compliant: Yes
-        notes: ''
+      monitoring-heartbeat-error:
+        compliant: Yes
+      monitoring-requests-id:
+        compliant: Yes
+      monitoring-backends-duration:
+        compliant: Partially
+      telemetry-metrics:
+        compliant: No
+      telemetry-naming:
+        compliant: Partially
+      telemetry-documented:
+        compliant: Partially
+      telemetry-query-examples:
+        compliant: Partially
+      notifications-error-chat:
+        compliant: No
+      documentation-security-assessment:
+        compliant: No
+      documentation-test-args:
+        compliant: Yes
+      documentation-operator:
+        compliant: Partially
+      documentation-troubleshooting:
+        compliant: Partially
+Remote Settings:
+  '2023-03-04':
+    version: 1
+    score: 73
+    max_score: 110
+    rules:
+      repo-standard-files:
+        compliant: Partially
+        notes: Missing CONTRIBUTING.md, SECURITY.md
+      repo-standard-folders:
+        compliant: Yes
+      repo-readme-sections:
+        compliant: No
+        notes: Missing status badge, Usage is called “Run”
+      repo-makefile-targets:
+        compliant: Partially
+        notes: Missing help
+      repo-main-branch-name:
+        compliant: Yes
+      repo-main-branch-protected:
+        compliant: Yes
+      repo-version-tags-protected:
+        compliant: Yes
+      repo-issue-labels:
+        compliant: Yes
+      repo-team-reviewers-permissions:
+        compliant: Yes
+      repo-pull-request-merge:
+        compliant: Yes
+      repo-pre-commit-optional:
+        compliant: Partially
+        notes: No pre-commit :)
+      repo-release-notes-auto:
+        compliant: No
+        notes: We use a CHANGELOG.rst file.
+      repo-dependencies-auto:
+        compliant: Yes
+      repo-automerge-enabled:
+        compliant: Yes
+      repo-head-branch-auto-delete:
+        compliant: Yes
+      repo-code-owners:
+        compliant: Yes
+      test-lint-secrets:
+        compliant: No
+      test-lint-code-format:
+        compliant: Yes
+      test-lint-static-analysis:
+        compliant: Partially
+        notes: Only flake8
+      test-lint-type-checking:
+        compliant: No
+      test-unit-coverage:
+        compliant: Yes
+      test-documentation-build:
+        compliant: Yes
+      test-container-build:
+        compliant: Yes
+      test-container-integration:
+        compliant: Yes
+      test-pull-requests-labels:
+        compliant: No
+      dependencies-reproducibility:
+        compliant: Yes
+      release-semver-calver:
+        compliant: Yes
+      release-tag-v-prefix:
+        compliant: No
+      release-tag-only:
+        compliant: No
+        notes: Requires a pull-request to update VERSION and CHANGELOG.rst files
+      release-publish:
+        compliant: Yes
+      deployment-dockerflow:
+        compliant: Yes
+      deployment-integration-test:
+        compliant: No
+        notes: This is planned for H1/H2 2023
+      deployment-auto-main:
+        compliant: Yes
+      deployment-auto-release:
+        compliant: Yes
+      deployment-auto-pull-requests:
+        compliant: No
+        notes: No temporary instance deployed on pull-requests.
+      monitoring-heartbeat-backends:
+        compliant: Yes
+      monitoring-heartbeat-error:
+        compliant: Yes
+      monitoring-requests-duration:
+        compliant: Yes
+      monitoring-requests-id:
+        compliant: No
+      monitoring-backends-duration:
+        compliant: Yes
+      monitoring-logging-level:
+        compliant: Yes
+      monitoring-logging-mozlog:
+        compliant: Yes
+      monitoring-logging-env-configuration:
+        compliant: No
+        notes: via .ini
+      monitoring-error-reporting:
+        compliant: Yes
+      telemetry-metrics:
+        compliant: Yes
+      telemetry-naming:
+        compliant: Yes
+      telemetry-documented:
+        compliant: No
+      telemetry-query-examples:
+        compliant: No
+      notifications-error-chat:
+        compliant: No
+      documentation-decisions-records:
+        compliant: Yes
+      documentation-security-assessment:
+        compliant: No
+        notes: No link
+      documentation-dev:
+        compliant: Yes
+      documentation-test-args:
+        compliant: No
+      documentation-operator:
+        compliant: Partially
+        notes: Only via Kinto
+      documentation-troubleshooting:
+        compliant: Yes
+  '2023-09-04':
+    version: 1
+    score: 94
+    max_score: 110
+    rules:
+      repo-standard-folders:
+        compliant: Yes
+      repo-main-branch-name:
+        compliant: Yes
+      repo-main-branch-protected:
+        compliant: Yes
+      repo-version-tags-protected:
+        compliant: Yes
+      repo-issue-labels:
+        compliant: Yes
+      repo-team-reviewers-permissions:
+        compliant: Yes
+      repo-pull-request-merge:
+        compliant: Yes
+      repo-dependencies-auto:
+        compliant: Yes
+      repo-automerge-enabled:
+        compliant: Yes
+      repo-head-branch-auto-delete:
+        compliant: Yes
+      repo-code-owners:
+        compliant: Yes
+      test-lint-code-format:
+        compliant: Yes
+      test-unit-coverage:
+        compliant: Yes
+      test-documentation-build:
+        compliant: Yes
+      test-container-build:
+        compliant: Yes
+      test-container-integration:
+        compliant: Yes
+      dependencies-reproducibility:
+        compliant: Yes
+      release-semver-calver:
+        compliant: Yes
+      release-publish:
+        compliant: Yes
+      deployment-dockerflow:
+        compliant: Yes
+      deployment-auto-main:
+        compliant: Yes
+      deployment-auto-release:
+        compliant: Yes
+      monitoring-heartbeat-backends:
+        compliant: Yes
+      monitoring-heartbeat-error:
+        compliant: Yes
+      monitoring-requests-duration:
+        compliant: Yes
+      monitoring-backends-duration:
+        compliant: Yes
+      monitoring-logging-level:
+        compliant: Yes
+      monitoring-logging-mozlog:
+        compliant: Yes
+      monitoring-error-reporting:
+        compliant: Yes
+      telemetry-metrics:
+        compliant: Yes
+      telemetry-naming:
+        compliant: Yes
+      documentation-decisions-records:
+        compliant: Yes
+      documentation-dev:
+        compliant: Yes
+      documentation-troubleshooting:
+        compliant: Yes
+      repo-standard-files:
+        compliant: Yes
+      repo-readme-sections:
+        compliant: Yes
+      repo-makefile-targets:
+        compliant: Yes
+      repo-pre-commit-optional:
+        compliant: Yes
+      repo-release-notes-auto:
+        compliant: Yes
+      test-lint-secrets:
+        compliant: Yes
+      test-lint-static-analysis:
+        compliant: Partially
+      test-lint-type-checking:
+        compliant: No
+      test-pull-requests-labels:
+        compliant: Yes
+      release-tag-v-prefix:
+        compliant: Yes
+      release-tag-only:
+        compliant: Yes
+      deployment-integration-test:
+        compliant: No
+      deployment-auto-pull-requests:
+        compliant: No
+      monitoring-requests-id:
+        compliant: Yes
+      monitoring-logging-env-configuration:
+        compliant: No
+      telemetry-documented:
+        compliant: No
+      telemetry-query-examples:
+        compliant: No
+      notifications-error-chat:
+        compliant: Yes
+      documentation-security-assessment:
+        compliant: Yes
+      documentation-test-args:
+        compliant: No
+      documentation-operator:
+        compliant: Partially

--- a/docs/quality-standards/scorecards.yaml
+++ b/docs/quality-standards/scorecards.yaml
@@ -971,3 +971,144 @@ Remote Settings:
         compliant: No
       documentation-operator:
         compliant: Partially
+Tecken:
+  '2023-10-06':
+    version: 1
+    score: 50
+    max_score: 110
+    rules:
+      repo-standard-files:
+        compliant: Partially
+        notes: Missing SECURITY and SUPPORT files
+      repo-standard-folders:
+        compliant: Yes
+      repo-readme-sections:
+        compliant: Partially
+        notes: Missing status
+      repo-makefile-targets:
+        compliant: Partially
+        notes: '`run` instead of `start` and `lintfix` instead of `format`'
+      repo-main-branch-name:
+        compliant: Yes
+      repo-main-branch-protected:
+        compliant: Unknown
+      repo-version-tags-protected:
+        compliant: No
+      repo-issue-labels:
+        compliant: Yes
+        notes: No issue tracker.
+      repo-team-reviewers-permissions:
+        compliant: Unknown
+      repo-pull-request-merge:
+        compliant: Unknown
+      repo-pre-commit-optional:
+        compliant: Yes
+        notes: No precommit hook
+      repo-release-notes-auto:
+        compliant: No
+        notes: Changelog is put in tag annotation
+      repo-dependencies-auto:
+        compliant: Yes
+      repo-automerge-enabled:
+        compliant: Unknown
+      repo-head-branch-auto-delete:
+        compliant: Unknown
+      repo-code-owners:
+        compliant: No
+      test-lint-secrets:
+        compliant: No
+      test-lint-code-format:
+        compliant: Yes
+      test-lint-static-analysis:
+        compliant: Yes
+        notes: Using ruff
+      test-lint-type-checking:
+        compliant: No
+      test-unit-coverage:
+        compliant: No
+        notes: No coverage mesurement
+      test-documentation-build:
+        compliant: Yes
+      test-container-build:
+        compliant: Yes
+      test-container-integration:
+        compliant: Partially
+        notes: Frontend tests are ran. System tests exist.
+      test-pull-requests-labels:
+        compliant: No
+      dependencies-reproducibility:
+        compliant: Yes
+      release-semver-calver:
+        compliant: Yes
+      release-tag-v-prefix:
+        compliant: No
+      release-tag-only:
+        compliant: Yes
+      release-publish:
+        compliant: Yes
+      deployment-dockerflow:
+        compliant: Yes
+        notes: Uses python-dockerflow with Django
+      deployment-integration-test:
+        compliant: Unknown
+      deployment-auto-main:
+        compliant: Unknown
+      deployment-auto-release:
+        compliant: Unknown
+      deployment-auto-pull-requests:
+        compliant: No
+      monitoring-heartbeat-backends:
+        compliant: Yes
+        notes:
+          https://github.com/mozilla-services/tecken/blob/3543f9d39f12cd65da1539341692663fd4621778/tecken/settings.py#L585-L588
+      monitoring-heartbeat-error:
+        compliant: Unknown
+      monitoring-requests-duration:
+        compliant: Unknown
+        notes: Didn't see middleware/requests.summary. Maybe part of python-dockerflow
+      monitoring-requests-id:
+        compliant: Unknown
+      monitoring-backends-duration:
+        compliant: Partially
+        notes: metrics are used to monitor uploads/downloads, but apparently not for
+          database/cache calls
+      monitoring-logging-level:
+        compliant: Yes
+      monitoring-logging-mozlog:
+        compliant: Yes
+        notes:
+          https://github.com/mozilla-services/tecken/blob/3543f9d39f12cd65da1539341692663fd4621778/tecken/settings.py#L170-L171
+      monitoring-logging-env-configuration:
+        compliant: Partially
+        notes: human format only in DEV, not configurable, and default level using
+          LOGGING_DEFAULT_LEVEL env var
+          https://github.com/mozilla-services/tecken/blob/3543f9d39f12cd65da1539341692663fd4621778/tecken/settings.py#L87-L91
+      monitoring-error-reporting:
+        compliant: No
+        notes:
+          https://github.com/mozilla-services/tecken/blob/3543f9d39f12cd65da1539341692663fd4621778/bin/sentry-wrap.py#L43C21-L43C31  Not
+          environment / version passed to init
+      telemetry-metrics:
+        compliant: Yes
+        notes: Using markus
+      telemetry-naming:
+        compliant: Yes
+      telemetry-documented:
+        compliant: Yes
+        notes: A command allows to list them, but not explicitly listed in docs
+      telemetry-query-examples:
+        compliant: No
+      notifications-error-chat:
+        compliant: Unknown
+      documentation-decisions-records:
+        compliant: Yes
+      documentation-security-assessment:
+        compliant: No
+      documentation-dev:
+        compliant: Yes
+      documentation-test-args:
+        compliant: No
+      documentation-operator:
+        compliant: No
+      documentation-troubleshooting:
+        compliant: No

--- a/docs/quality-standards/template.html
+++ b/docs/quality-standards/template.html
@@ -2,6 +2,8 @@
 <html lang="en">
 <head>
   <title>Quality Standards</title>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <style>
     body {
       font-family: sans-serif;
@@ -63,19 +65,19 @@
     <table>
       <thead>
         <tr>
-          {% for date in results.keys() %}
+          {% for date in results|sort(reverse=True) %}
           <td>{{ date }}</td>
           {% endfor %}
         </tr>
       </thead>
       <tbody>
         <tr>
-          {% for result in results.values() %}
+          {% for _, result in results.items()|sort(reverse=True) %}
           <td>{{ (result.score / result.max_score * 100)|round|int }}% ({{ result.score }} / {{ result.max_score }})</td>
           {% endfor %}
         </tr>
         <tr>
-          {% for result in results.values() %}
+          {% for _, result in results.items()|sort(reverse=True) %}
           <td>
             Missing from standard v{{ result.version }}:
             <ul>

--- a/docs/quality-standards/template.html
+++ b/docs/quality-standards/template.html
@@ -12,6 +12,73 @@
       font-family: monospace;
       background-color: bisque;
     }
+
+    section#rules {
+      table {
+        border-collapse: collapse;
+        margin: 25px 0;
+        font-size: 0.9em;
+        min-width: 400px;
+        max-width: 70%;
+        box-shadow: 0 0 20px rgba(0, 0, 0, 0.15);
+
+        col:first-child {
+          width: 20%;
+        }
+        col:nth-child(2),
+        col:nth-child(3) {
+          width: 40%;
+        }
+
+        thead tr {
+          background-color: #009879;
+          color: #ffffff;
+          text-align: left;
+        }
+
+        th, td {
+          padding: 12px 15px;
+          vertical-align: top;
+        }
+
+        td p {
+          margin-top: 0px;
+        }
+
+        tbody {
+          tr {
+            border-bottom: 1px solid #dddddd;
+          }
+
+          tr:nth-of-type(even) {
+            background-color: #f3f3f3;
+          }
+
+          tr:last-of-type {
+            border-bottom: 2px solid #009879;
+          }
+        }
+      }
+    }
+
+    section#scorecards {
+      .card {
+        display: inline-block;
+        box-shadow: 0 0 20px rgba(0, 0, 0, 0.15);
+        border-bottom: 1px solid #dddddd;
+        max-width: 30%;
+        margin-right: 20px;
+        margin-bottom: 20px;
+
+
+        .container {
+          display: flex;
+          flex-direction: column;
+          justify-content: center;
+          align-items: center;
+        }
+      }
+    }
   </style>
 </head>
 <body>
@@ -21,9 +88,9 @@
     <h2>Table of Contents</h2>
     <h3>Rules</h3>
     <ul>
-        {% for category in standard.categories %}
-        <li><a href="#category-{{ category.title }}">{{ category.title }}</a></hli>
-        {% endfor %}
+      {% for category in standard.categories %}
+      <li><a href="#category-{{ category.title }}">{{ category.title }}</a></hli>
+      {% endfor %}
     </ul>
     <h3>Score Cards</h3>
     <ul>
@@ -34,67 +101,60 @@
   </section>
   <h2>Score Cards</h2>
   {% for category in standard.categories %}
-  <section class="rules">
+  <section id="rules">
     <h3><a name="category-{{ category.title }}">{{ category.title }}</a></h3>
     <p>{{ category.description|default('')|markdown }}</p>
     <table>
-        <thead>
-            <tr>
-                <td>Rule</td>
-                <td>Description</td>
-                <td>Details</td>
-            </tr>
-        </thead>
-        <tbody>
-            {% for name, rule in category.rules.items() %}
-            <tr>
-                <td><span class="rulename">{{ name }}</span></td>
-                <td>{{ rule.description|markdown }}</td>
-                <td>{{ rule.details|default('')|markdown }}</td>
-            </tr>
-            {% endfor %}
-        </tbody>
+      <colgroup>
+        <col>
+        <col>
+        <col>
+      </colgroup>
+      <thead>
+        <tr>
+          <td>Rule</td>
+          <td>Description</td>
+          <td>Details</td>
+        </tr>
+      </thead>
+      <tbody>
+        {% for name, rule in category.rules.items() %}
+        <tr>
+          <td><span class="rulename">{{ name }}</span></td>
+          <td>{{ rule.description|markdown }}</td>
+          <td>{{ rule.details|default('')|markdown }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
     </table>
   </section>
   {% endfor %}
 
   <h1>Score Cards</h1>
   {% for service, results in scorecards.items() %}
-  <section>
+  <section id="scorecards">
     <h2><a name="service-{{ service }}">{{ service }}</a></h2>
-    <table>
-      <thead>
-        <tr>
-          {% for date in results|sort(reverse=True) %}
-          <td>{{ date }}</td>
-          {% endfor %}
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          {% for _, result in results.items()|sort(reverse=True) %}
-          <td>{{ (result.score / result.max_score * 100)|round|int }}% ({{ result.score }} / {{ result.max_score }})</td>
-          {% endfor %}
-        </tr>
-        <tr>
-          {% for _, result in results.items()|sort(reverse=True) %}
-          <td>
-            Missing from standard v{{ result.version }}:
-            <ul>
-              {% for name, details in result.rules.items() %}
-                {% if details.compliant != "Yes" %}
-                <li>
-                  <span class="rulename">{{ name }}</span>: {{ details.compliant }}
-                  {% if details.notes %}({{ details.notes }}){% endif %}
-                </li>
-                {% endif %}
-              {% endfor %}
-            </ul>
-          </td>
-          {% endfor %}
-        </tr>
-      </tbody>
-    </table>
+
+    {% for date, result in results.items()|sort(reverse=True) %}
+    <div class="card">
+      <div class="container">
+        <h3>{{ (result.score / result.max_score * 100)|round|int }}% ({{ result.score }} / {{ result.max_score }}), {{ date }}</h3>
+        <p>
+          Missing from standard v{{ result.version }}:
+          <ul>
+           {% for name, details in result.rules.items() %}
+             {% if details.compliant != "Yes" %}
+             <li>
+               <span class="rulename">{{ name }}</span>: {{ details.compliant }}
+               {% if details.notes %}({{ details.notes }}){% endif %}
+             </li>
+             {% endif %}
+           {% endfor %}
+          </ul>
+        </p>
+      </div>
+    </div>
+    {% endfor %}
   </section>
   {% endfor %}
 </body>

--- a/docs/quality-standards/template.html
+++ b/docs/quality-standards/template.html
@@ -6,6 +6,10 @@
     body {
       font-family: sans-serif;
     }
+    .rulename {
+      font-family: monospace;
+      background-color: bisque;
+    }
   </style>
 </head>
 <body>
@@ -13,15 +17,22 @@
   <p>{{ standard.description|markdown }}</p>
   <section id="toc">
     <h2>Table of Contents</h2>
+    <h3>Rules</h3>
     <ul>
         {% for category in standard.categories %}
-        <li><a href="#{{ category.title }}">{{ category.title }}</a></hli>
+        <li><a href="#category-{{ category.title }}">{{ category.title }}</a></hli>
         {% endfor %}
+    </ul>
+    <h3>Score Cards</h3>
+    <ul>
+      {% for service in scorecards %}
+      <li><a href="#service-{{ service }}">{{ service }}</a></hli>
+      {% endfor %}
     </ul>
   </section>
   {% for category in standard.categories %}
   <section class="rules">
-    <h2><a name="{{ category.title }}">{{ category.title }}</a></h2>
+    <h2><a name="category-{{ category.title }}">{{ category.title }}</a></h2>
     <p>{{ category.description|default('')|markdown }}</p>
     <table>
         <thead>
@@ -34,12 +45,52 @@
         <tbody>
             {% for name, rule in category.rules.items() %}
             <tr>
-                <td>{{ name }}</td>
+                <td><span class="rulename">{{ name }}</span></td>
                 <td>{{ rule.description|markdown }}</td>
                 <td>{{ rule.details|default('')|markdown }}</td>
             </tr>
             {% endfor %}
         </tbody>
+    </table>
+  </section>
+  {% endfor %}
+
+  <h1>Score Cards</h1>
+  {% for service, results in scorecards.items() %}
+  <section>
+    <h2><a name="service-{{ service }}">{{ service }}</a></h2>
+    <table>
+      <thead>
+        <tr>
+          {% for date in results.keys() %}
+          <td>{{ date }}</td>
+          {% endfor %}
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          {% for result in results.values() %}
+          <td>{{ (result.score / result.max_score * 100)|round|int }}% ({{ result.score }} / {{ result.max_score }})</td>
+          {% endfor %}
+        </tr>
+        <tr>
+          {% for result in results.values() %}
+          <td>
+            Missing from standard v{{ result.version }}:
+            <ul>
+              {% for name, details in result.rules.items() %}
+                {% if details.compliant != "Yes" %}
+                <li>
+                  <span class="rulename">{{ name }}</span>: {{ details.compliant }}
+                  {% if details.notes %}({{ details.notes }}){% endif %}
+                </li>
+                {% endif %}
+              {% endfor %}
+            </ul>
+          </td>
+          {% endfor %}
+        </tr>
+      </tbody>
     </table>
   </section>
   {% endfor %}

--- a/docs/quality-standards/template.html
+++ b/docs/quality-standards/template.html
@@ -13,6 +13,11 @@
       background-color: bisque;
     }
 
+    blockquote {
+      border-left: solid 4px lightgray;
+      padding-left: 10px;
+    }
+
     section#rules {
       table {
         border-collapse: collapse;

--- a/docs/quality-standards/template.html
+++ b/docs/quality-standards/template.html
@@ -18,7 +18,7 @@
       padding-left: 10px;
     }
 
-    section#rules {
+    section.rules {
       table {
         border-collapse: collapse;
         margin: 25px 0;
@@ -66,7 +66,7 @@
       }
     }
 
-    section#scorecards {
+    section.scorecards {
       .card {
         display: inline-block;
         box-shadow: 0 0 20px rgba(0, 0, 0, 0.15);
@@ -74,6 +74,7 @@
         max-width: 30%;
         margin-right: 20px;
         margin-bottom: 20px;
+        padding-right: 20px;
 
 
         .container {
@@ -95,21 +96,21 @@
     <h3>Rules</h3>
     <ul>
       {% for category in standard.categories %}
-      <li><a href="#category-{{ category.title }}">{{ category.title }}</a></hli>
+      <li><a href="#category-{{ category.title }}">{{ category.title }}</a></li>
       {% endfor %}
     </ul>
     <h3>Score Cards</h3>
     <ul>
       {% for service in scorecards %}
-      <li><a href="#service-{{ service }}">{{ service }}</a></hli>
+      <li><a href="#service-{{ service }}">{{ service }}</a></li>
       {% endfor %}
     </ul>
   </section>
   <h2>Score Cards</h2>
   {% for category in standard.categories %}
-  <section id="rules">
+  <section class="rules">
     <h3><a name="category-{{ category.title }}">{{ category.title }}</a></h3>
-    <p>{{ category.description|default('')|markdown }}</p>
+    {{ category.description|default('')|markdown }}
     <table>
       <colgroup>
         <col>
@@ -138,26 +139,24 @@
 
   <h1>Score Cards</h1>
   {% for service, results in scorecards.items() %}
-  <section id="scorecards">
+  <section class="scorecards">
     <h2><a name="service-{{ service }}">{{ service }}</a></h2>
 
     {% for date, result in results.items()|sort(reverse=True) %}
     <div class="card">
       <div class="container">
         <h3>{{ (result.score / result.max_score * 100)|round|int }}% ({{ result.score }} / {{ result.max_score }}), {{ date }}</h3>
-        <p>
-          Missing from standard v{{ result.version }}:
-          <ul>
-           {% for name, details in result.rules.items() %}
-             {% if details.compliant != "Yes" %}
-             <li>
-               <span class="rulename">{{ name }}</span>: {{ details.compliant }}
-               {% if details.notes %}({{ details.notes }}){% endif %}
-             </li>
-             {% endif %}
-           {% endfor %}
-          </ul>
-        </p>
+        <p>Missing from standard v{{ result.version }}:</p>
+        <ul>
+         {% for name, details in result.rules.items() %}
+           {% if details.compliant != "Yes" %}
+           <li>
+             <span class="rulename">{{ name }}</span>: {{ details.compliant }}
+             {% if details.notes %}({{ details.notes }}){% endif %}
+           </li>
+           {% endif %}
+         {% endfor %}
+        </ul>
       </div>
     </div>
     {% endfor %}

--- a/docs/quality-standards/template.html
+++ b/docs/quality-standards/template.html
@@ -11,8 +11,17 @@
 <body>
   <h1>Quality Standards</h1>
   <p>{{ standard.description|markdown }}</p>
+  <section id="toc">
+    <h2>Table of Contents</h2>
+    <ul>
+        {% for category in standard.categories %}
+        <li><a href="#{{ category.title }}">{{ category.title }}</a></hli>
+        {% endfor %}
+    </ul>
+  </section>
   {% for category in standard.categories %}
-    <h2>{{ category.title }}</h2>
+  <section class="rules">
+    <h2><a name="{{ category.title }}">{{ category.title }}</a></h2>
     <p>{{ category.description|default('')|markdown }}</p>
     <table>
         <thead>
@@ -32,6 +41,7 @@
             {% endfor %}
         </tbody>
     </table>
+  </section>
   {% endfor %}
 </body>
 </html>

--- a/docs/quality-standards/template.html
+++ b/docs/quality-standards/template.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>Quality Standards</title>
+  <style>
+    body {
+      font-family: sans-serif;
+    }
+  </style>
+</head>
+<body>
+  <h1>Quality Standards</h1>
+  <p>{{ standard.description|markdown }}</p>
+  {% for category in standard.categories %}
+    <h2>{{ category.title }}</h2>
+    <p>{{ category.description|default('')|markdown }}</p>
+    <table>
+        <thead>
+            <tr>
+                <td>Rule</td>
+                <td>Description</td>
+                <td>Details</td>
+            </tr>
+        </thead>
+        <tbody>
+            {% for name, rule in category.rules.items() %}
+            <tr>
+                <td>{{ name }}</td>
+                <td>{{ rule.description|markdown }}</td>
+                <td>{{ rule.details|default('')|markdown }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+  {% endfor %}
+</body>
+</html>

--- a/docs/quality-standards/template.html
+++ b/docs/quality-standards/template.html
@@ -83,6 +83,7 @@
 </head>
 <body>
   <h1>Quality Standards</h1>
+  <p>Version {{ standard.version }}, last updated on {{ criteria_last_update.strftime('%Y-%m-%d') }}</p>
   <p>{{ standard.description|markdown }}</p>
   <section id="toc">
     <h2>Table of Contents</h2>

--- a/docs/quality-standards/template.html
+++ b/docs/quality-standards/template.html
@@ -74,6 +74,7 @@
         max-width: 30%;
         margin-right: 20px;
         margin-bottom: 20px;
+        padding-left: 20px;
         padding-right: 20px;
 
 
@@ -82,6 +83,33 @@
           flex-direction: column;
           justify-content: center;
           align-items: center;
+
+          .punchs {
+            max-width: 20em;
+
+            .punch {
+              height: 10px;
+              width: 10px;
+              display: inline-block;
+              border-radius: 2px;
+
+              &.yes {
+                background-color: green;
+              }
+
+              &.no {
+                background-color: red;
+              }
+
+              &.partially {
+                background-color: yellow;
+              }
+
+              &.unknown {
+                background-color: lightgray;
+              }
+            }
+          }
         }
       }
     }
@@ -146,17 +174,47 @@
     <div class="card">
       <div class="container">
         <h3>{{ (result.score / result.max_score * 100)|round|int }}% ({{ result.score }} / {{ result.max_score }}), {{ date }}</h3>
-        <p>Missing from standard v{{ result.version }}:</p>
-        <ul>
-         {% for name, details in result.rules.items() %}
-           {% if details.compliant != "Yes" %}
-           <li>
-             <span class="rulename">{{ name }}</span>: {{ details.compliant }}
-             {% if details.notes %}({{ details.notes }}){% endif %}
-           </li>
-           {% endif %}
-         {% endfor %}
-        </ul>
+        <div class="punchs">
+          {% for name, details in result.rules.items() %}
+          <div class="punch {{ details.compliant|lower }}" title="{{ name }}"></div>
+          {% endfor %}
+        </div>
+
+        {% set ns = namespace(iterated=false) %}
+        {% for name, details in result.rules.items() %}
+          {% if details.compliant in ("No", "Partially") %}
+            {% if not ns.iterated %}
+              <p>Missing from standard v{{ result.version }}:</p>
+                <ul>
+            {% endif %}
+            {% set ns.iterated = true %}
+            <li>
+              <span class="rulename">{{ name }}</span>: {{ details.compliant }}
+              {% if details.notes %}({{ details.notes }}){% endif %}
+            </li>
+          {% endif %}
+          {% if loop.last %}
+            </ul>
+          {% endif %}
+        {% endfor %}
+
+        {% set ns = namespace(iterated=false) %}
+        {% for name, details in result.rules.items() %}
+          {% if details.compliant == "Unknown" %}
+            {% if not ns.iterated %}
+              <p>Could not be verified:</p>
+                <ul>
+            {% endif %}
+            {% set ns.iterated = true %}
+            <li>
+              <span class="rulename">{{ name }}</span>
+              {% if details.notes %}: ({{ details.notes }}){% endif %}
+            </li>
+          {% endif %}
+          {% if loop.last %}
+            </ul>
+          {% endif %}
+        {% endfor %}
       </div>
     </div>
     {% endfor %}

--- a/docs/quality-standards/template.html
+++ b/docs/quality-standards/template.html
@@ -30,9 +30,10 @@
       {% endfor %}
     </ul>
   </section>
+  <h2>Score Cards</h2>
   {% for category in standard.categories %}
   <section class="rules">
-    <h2><a name="category-{{ category.title }}">{{ category.title }}</a></h2>
+    <h3><a name="category-{{ category.title }}">{{ category.title }}</a></h3>
     <p>{{ category.description|default('')|markdown }}</p>
     <table>
         <thead>


### PR DESCRIPTION
Toolbox to generate https://mozilla.github.io/syseng-pod/quality-standards/

* `./manage.py html` : turn the YAML with standards into HTML
* `./manage.py audit` : prompt for compliance of quality rules, shows score and save result

A proof of concept with the following goals:

- turn quality standards into formal files
- allow standard to be versioned
- run audits on services and keep track over time

Plan

* [x] Turn the standard docs into a YAML file
* [x] Turn the YAML file into standard docs using generated HTML
* [x] Add an audit CLI to track projects compliance and save scorecards in YAML
* [x] Resume a previous audit
* [x] Start a new audit using the previous results
* [x] Turn the YAML score cards into an HTML report  
* [x] Fix ugly style and make it look nice
* [x] Publish everything on github pages
* [x] Add README
* [ ] Get peer feedback

After merge

* [ ] Tag v1 of standard
* [ ] Onboard new projects

https://github.com/mozilla/syseng-pod/assets/546692/3e17e117-7a08-4274-b669-334f60b5f1e9

