### PR TITLE
Update Dependabot Automerge action

### DIFF
--- a/actions/dependabot-automerge/action.yml
+++ b/actions/dependabot-automerge/action.yml
@@ -20,14 +20,14 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.12'
     - shell: bash
       run: pip install click
     - name: Dependabot metadata
       id: dependabot-metadata
-      uses: dependabot/fetch-metadata@v1
+      uses: dependabot/fetch-metadata@v2
       with:
         github-token: ${{ inputs.github-token }}
     - name: Review PR


### PR DESCRIPTION
- update `actions/setup-python` to v5
- bump Python to 3.12
- update `dependabot/fetch-metadata` action to v2

I noticed https://github.com/mozilla/jira-bugzilla-integration/actions/runs/9169408262/job/25209779546?pr=1005 failed, and I also noticed that we were a major version behind of `fetch-metadata`, and I thought that might be the cause
